### PR TITLE
added logging env vars to set log level for error resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [1.1.2] - 2021-06-20
 ### Added
 - added default layouts for non-flat output directories - (resolves https://github.com/podaac/data-subscriber/issues/6)
+- Added logging capability using the SUBSCRIBER_LOGLEVEL environment variable
 ### Changed
 ### Deprecated
 ### Removed

--- a/README.md
+++ b/README.md
@@ -175,6 +175,16 @@ But now that you've recieved the older data (the -ds data since flag), you can r
 
 ## Advanced Usage
 
+### Logging
+
+For error troubleshooting, one can set an environment variable to gain more insight into errors:
+
+```
+export SUBSCRIBER_LOGLEVEL=DEBUG
+```
+
+And then run the script. This should give you more verbose output on URL requests to CMR, tokens, etc.
+
 ### Controlling output directories
 
 The subscriber allows the placement of downloaded files into one of several directory structures based on the flags used to run the subscriber.

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='podaac-data-subscriber',
-      version='1.1.1',
+      version='1.1.2',
       description='PO.DAAC Data Susbcriber Command Line Tool',
       url='https://github.com/podaac/data-subscriber',
       author='PO.DAAC',

--- a/subscriber/podaac_data_subscriber.py
+++ b/subscriber/podaac_data_subscriber.py
@@ -17,9 +17,15 @@ import socket
 import sys
 import argparse
 import datetime
+import logging
+import os
 
-__version__ = "1.1.1"
+__version__ = "1.1.2"
 
+LOGLEVEL = os.environ.get('SUBSCRIBER_LOGLEVEL', 'WARNING').upper()
+logging.basicConfig(level=LOGLEVEL)
+
+logging.debug("Log level set to " + LOGLEVEL)
 
 ## TODO: ???
 def validate(args):


### PR DESCRIPTION
Mostly to allow more resolution on errors coming from request library calls. Will be very messy if this is run all the time, so default is 'warning'