### PR TITLE
Feature/PODAAC-3869 - detect and re-download updated granules based on collection redeliveries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 
+## [1.4.0] - 2021-10-05
+### Added
+### Changed
+- changed changing created_at to updated_since to allow for re-download of updated granules based on collection redeliveries - (resolves https://github.com/podaac/data-subscriber/issues/18)
+### Deprecated
+### Removed
+### Fixed
+### Security
+
+
 ## [1.3.0] - 2021-08-26
 ### Added
 - added additional non-flat output directory option of -dy - (resolves https://github.com/podaac/data-subscriber/issues/13)
@@ -30,7 +40,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added logging capability using the SUBSCRIBER_LOGLEVEL environment variable
 - added additional non-flat output directory option of -dy - (resolves https://github.com/podaac/data-subscriber/issues/13)
 ### Changed
-- changed changing created_at to updated_since to allow for re-download of updated granules based on collection redeliveries - (resolves https://github.com/podaac/data-subscriber/issues/18)
 ### Deprecated
 ### Removed
 ### Fixed

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='podaac-data-subscriber',
-      version='1.3.0',
+      version='1.4.0',
       description='PO.DAAC Data Susbcriber Command Line Tool',
       url='https://github.com/podaac/data-subscriber',
       author='PO.DAAC',

--- a/subscriber/podaac_data_subscriber.py
+++ b/subscriber/podaac_data_subscriber.py
@@ -29,7 +29,7 @@ from urllib.parse import urlencode
 from urllib.request import urlopen, urlretrieve
 from datetime import datetime, timedelta
 
-__version__ = "1.3.0"
+__version__ = "1.4.0"
 
 LOGLEVEL = os.environ.get('SUBSCRIBER_LOGLEVEL', 'WARNING').upper()
 logging.basicConfig(level=LOGLEVEL)


### PR DESCRIPTION
Ticket: [PODAAC-3869](https://jira.jpl.nasa.gov/browse/PODAAC-3869)
Ticket: [Issue-#18](https://github.com/podaac/data-subscriber/issues/18)

### Description

Update CMR query to use `updated_since` rather than `created_at` in the CMR query:
```
    params = {
        'scroll': "true",
        'page_size': 2000,
        'sort_key': "-start_date",
        'provider': 'POCLOUD',
        'ShortName': short_name,
        'created_at': data_within_last_timestamp,
        'token': token,
        'bounding_box': bounding_extent,
    }
```
https://cmr.earthdata.nasa.gov/search/site/docs/search/api.html#c-updated-since

here:
https://github.com/podaac/data-subscriber/blob/main/subscriber/podaac_data_subscriber.py#L298

as well as here:
https://github.com/podaac/data-subscriber/blob/main/subscriber/podaac_data_subscriber.py#L310


### Overview of work done

Changed `created_at` to `updated_since`:
```
    params = {
        'scroll': "true",
        'page_size': 2000,
        'sort_key': "-start_date",
        'provider': 'POCLOUD',
        'ShortName': short_name,
        'updated_since': data_within_last_timestamp,
        'token': token,
        'bounding_box': bounding_extent,
    }
```

Added updates to CHANGELOG.

#### Tested:

Tested locally and returns granules similar to `created_at`
