### PR TITLE
Don't consume all arguments after --extensions

### DIFF
--- a/subscriber/podaac_data_subscriber.py
+++ b/subscriber/podaac_data_subscriber.py
@@ -207,7 +207,7 @@ def create_parser():
     parser.add_argument("--offset", dest="offset", help = "Flag used to shift timestamp. Units are in hours, e.g. 10 or -10.")  # noqa E501
 
     parser.add_argument("-m", "--minutes", dest="minutes", help = "How far back in time, in minutes, should the script look for data. If running this script as a cron, this value should be equal to or greater than how often your cron runs (default: 60 minutes).", type=int, default=60)  # noqa E501
-    parser.add_argument("-e", "--extensions", dest="extensions", help = "The extensions of products to download. Default is [.nc, .h5, .zip]", default=[".nc", ".h5", ".zip"], nargs='*')  # noqa E501
+    parser.add_argument("-e", "--extensions", dest="extensions", help = "The extensions of products to download. Default is [.nc, .h5, .zip]", default=None, action='append')  # noqa E501
 
     parser.add_argument("--version", dest="version", action="store_true",help="Display script version information and exit.")  # noqa E501
     parser.add_argument("--verbose", dest="verbose", action="store_true",help="Verbose mode.")    # noqa E501
@@ -386,6 +386,8 @@ def run():
 
 
     #filter list based on extension
+    if not extensions:
+        extensions = [".nc", ".h5", ".zip"]
     filtered_downloads = []
     for f in downloads:
         for extension in extensions:


### PR DESCRIPTION
This behavior is more like other utilities, where specifying the flag
multiple times extends the value of the argument.  For example,
`-e '.nc .h5 .zip'`
becomes
`-e '.nc' -e '.h5' -e '.zip'`

This is possibly less confusing (I had to try several times to get the argument
formatting right).