### PR TITLE
Add retry logic for 500 and 401 errors from CMR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 ### Added
 ### Changed
+- Retry CMR queries on server error using random exponential backoff max 60 seconds and 10 retries
+- Refresh token if CMR returns 401 error
 - Converted print statements to log statements
 ### Deprecated
 ### Removed

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ chardet==4.0.0
 idna==2.10
 requests==2.25.1
 urllib3>=1.26.5
+tenacity>=8.0.1


### PR DESCRIPTION
We've been seeing a lot of 500 and 401 errors while testing for cloud downloads. This adds in some retry logic.

I'm not really sure of a great way to test this unfortunately.