### PR TITLE
Add checks for pre-existing files to downloader

### DIFF
--- a/Downloader.md
+++ b/Downloader.md
@@ -6,9 +6,7 @@ For installation and dependency information, please see the [top-level README](R
 
 ```
 $> podaac-data-downloader -h
-usage: PO.DAAC bulk-data downloader [-h] -c COLLECTION -d OUTPUTDIRECTORY [--cycle SEARCH_CYCLES] [-sd STARTDATE] [-ed ENDDATE]
-                                    [-b BBOX] [-dc] [-dydoy] [-dymd] [-dy] [--offset OFFSET] [-e EXTENSIONS] [--process PROCESS_CMD]
-                                    [--version] [--verbose] [-p PROVIDER] [--limit LIMIT]
+usage: PO.DAAC bulk-data downloader [-h] -c COLLECTION -d OUTPUTDIRECTORY [--cycle SEARCH_CYCLES] [-sd STARTDATE] [-ed ENDDATE] [-f] [-b BBOX] [-dc] [-dydoy] [-dymd] [-dy] [--offset OFFSET] [-e EXTENSIONS] [--process PROCESS_CMD] [--version] [--verbose] [-p PROVIDER] [--limit LIMIT]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -22,6 +20,8 @@ optional arguments:
                         The ISO date time before which data should be retrieved. For Example, --start-date 2021-01-14T00:00:00Z
   -ed ENDDATE, --end-date ENDDATE
                         The ISO date time after which data should be retrieved. For Example, --end-date 2021-01-14T00:00:00Z
+   -f, --force          
+                        Flag to force downloading files that are listed in CMR query, even if the file exists and checksum matches
   -b BBOX, --bounds BBOX
                         The bounding rectangle to filter result in. Format is W Longitude,S Latitude,E Longitude,N Latitude without
                         spaces. Due to an issue with parsing arguments, to use this command, please use the -b="-180,-90,180,90" syntax
@@ -50,7 +50,7 @@ optional arguments:
 
 Usage:
 ```
-usage: PO.DAAC bulk-data downloader [-h] -c COLLECTION -d OUTPUTDIRECTORY [--cycle SEARCH_CYCLES] [-sd STARTDATE] [-ed ENDDATE]
+usage: PO.DAAC bulk-data downloader [-h] -c COLLECTION -d OUTPUTDIRECTORY [--cycle SEARCH_CYCLES] [-sd STARTDATE] [-ed ENDDATE] [-f]
                                     [-b BBOX] [-dc] [-dydoy] [-dymd] [-dy] [--offset OFFSET] [-e EXTENSIONS] [--process PROCESS_CMD]
                                     [--version] [--verbose] [-p PROVIDER] [--limit LIMIT]
 ```
@@ -162,6 +162,22 @@ The subscriber allows the placement of downloaded files into one of several dire
 * -dydoy - optional, relative paths use the start time of a granule to layout data in a YEAR/DAY-OF-YEAR path
 * -dymd  - optional, relative paths use the start time of a granule to layout data in a YEAR/MONTH/DAY path
 
+
+### Downloader behavior when a file already exists
+
+By default, when the downloader is about to download a file, it first:
+- Checks if the file already exists in the target location
+- Creates a checksum for the file and sees if it matches the checksum for that file in CMR
+
+If the file already exists AND the checksum matches, the downloader will skip downloading that file.
+
+This can drastically reduce the time for the downloader to complete. Also, since the checksum is verified, files will still be re-downloaded if for some reason the file has changed (or the file already on disk is corrupted).
+
+You can override this default behavior - forcing the downloader to always download matching files, by using --force/-f.
+
+```
+podaac-data-downloader -c SENTINEL-1A_SLC -d myData -f
+```
 
 ### Setting a bounding rectangle for filtering results
 

--- a/Subscriber.md
+++ b/Subscriber.md
@@ -112,18 +112,6 @@ machine urs.earthdata.nasa.gov
 
 **If the script cannot find the netrc file, you will be prompted to enter the username and password and the script wont be able to generate the CMR token**
 
-## How the subscriber handles download failures
-
-If any downloads fail while the subscriber is running (e.g. a network failure), the subscriber will not record the current run as complete. However many of the data-files may have successfully downloaded. It could take a lot of extra time to re-download files the next time subscriber is run.
-
-Therefore, to prevent unnecessary re-downloading of files, the subscriber does a check before downloading each file. It checks if the file already exists in the output directory, and if the file is up to date (using the checksum). If the file is already there (and up to date), the default behavior is for the subscriber to skip downloading that file.
-
-You can override this default behavior - forcing the subscriber to always download files that show up in the search step, by using --force/-f.
-
-```
-podaac-data-subscriber -c SENTINEL-1A_SLC -d myData -f
-```
-
 
 ## Advanced Usage
 
@@ -153,6 +141,22 @@ The subscriber allows the placement of downloaded files into one of several dire
 * -dc - optional, if 'cycle' information exists in the product metadata, download it to the data directory and use a relative c<CYCLE> path to store granules. The relative path is 0 padded to 4 total digits (e.g. c0001)
 * -dydoy - optional, relative paths use the start time of a granule to layout data in a YEAR/DAY-OF-YEAR path
 * -dymd  - optional, relative paths use the start time of a granule to layout data in a YEAR/MONTH/DAY path
+
+### Subscriber behavior when a file already exists
+
+By default, when the subscriber is about to download a file, it first:
+- Checks if the file already exists in the target location
+- Creates a checksum for the file and sees if it matches the checksum for that file in CMR
+
+If the file already exists AND the checksum matches, the subscriber will skip downloading that file.
+
+This can drastically reduce the time for the subscriber to complete. Also, since the checksum is verified, files will still be re-downloaded if for some reason the file has changed (or the file already on disk is corrupted).
+
+You can override this default behavior - forcing the subscriber to always download matching files, by using --force/-f.
+
+```
+podaac-data-subscriber -c SENTINEL-1A_SLC -d myData -f
+```
 
 ### Running as a Cron job
 

--- a/subscriber/podaac_data_subscriber.py
+++ b/subscriber/podaac_data_subscriber.py
@@ -21,7 +21,6 @@ from os import makedirs
 from os.path import isdir, basename, join, isfile, exists
 from urllib.error import HTTPError
 from urllib.request import urlretrieve
-import hashlib
 
 from subscriber import podaac_access as pa
 
@@ -107,85 +106,6 @@ def create_parser():
                         help="Specify a provider for collection search. Default is POCLOUD.")  # noqa E501
     return parser
 
-
-def extract_checksums(granule_results):
-    """
-    Create a dictionary containing checksum information from files.
-
-    Parameters
-    ----------
-    granule_results : dict
-        The cmr granule search results (umm_json format)
-
-    Returns
-    -------
-    A dictionary where the keys are filenames and the values are
-    checksum information (checksum value and checksum algorithm).
-
-    For Example:
-    {
-        "some-granule-name.nc": {
-            "Value": "d96387295ea979fb8f7b9aa5f231c4ab",
-            "Algorithm": "MD5"
-        },
-        "some-granule-name.nc.md5": {
-            "Value": '320876f087da0876edc0876ab0876b7a",
-            "Algorithm": "MD5"
-        },
-        ...
-    }
-    """
-    checksums = {}
-    for granule in granule_results["items"]:
-        try:
-            items = granule["umm"]["DataGranule"]["ArchiveAndDistributionInformation"]
-            for item in items:
-                try:
-                    checksums[item["Name"]] = item["Checksum"]
-                except:
-                    pass
-        except:
-            pass
-    return checksums
-
-
-def checksum_does_match(file_path, checksums):
-    """
-    Checks if a file's checksum matches a checksum in the checksums dict
-
-    Parameters
-    ----------
-    file_path : string
-        The relative or absolute path to an existing file
-
-    checksums: dict
-        A dictionary where keys are filenames (not including the path)
-        and values are checksum information (checksum value and checksum algorithm)
-
-    Returns
-    -------
-    True - if the file's checksum matches a checksum in the checksum dict
-    False - if the file doesn't have a checksum, or if the checksum doesn't match
-    """
-    filename = basename(file_path)
-    checksum = checksums.get(filename)
-    if not checksum:
-        return False
-    return make_checksum(file_path, checksum["Algorithm"]) == checksum["Value"]
-
-
-def make_checksum(file_path, algorithm):
-    """
-    Create checksum of file using the specified algorithm
-    """
-    # Based on https://stackoverflow.com/questions/3431825/generating-an-md5-checksum-of-a-file#answer-3431838
-    # with modification to handle multiple algorithms
-    hash = getattr(hashlib, algorithm.lower())()
-
-    with open(file_path, 'rb') as f:
-        for chunk in iter(lambda: f.read(4096), b""):
-            hash.update(chunk)
-    return hash.hexdigest()
 
 
 def run():
@@ -323,13 +243,12 @@ def run():
     timestamp = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
 
     downloads_all = []
-
     downloads_data = [[u['URL'] for u in r['umm']['RelatedUrls'] if
                        u['Type'] == "GET DATA" and ('Subtype' not in u or u['Subtype'] != "OPENDAP DATA")] for r in
                       results['items']]
     downloads_metadata = [[u['URL'] for u in r['umm']['RelatedUrls'] if u['Type'] == "EXTENDED METADATA"] for r in
                           results['items']]
-    checksums = extract_checksums(results)
+    checksums = pa.extract_checksums(results)
 
     for f in downloads_data:
         downloads_all.append(f)
@@ -378,7 +297,7 @@ def run():
                     cycles, data_path, f)
 
             # decide if we should actually download this file (e.g. we may already have the latest version)
-            if(exists(output_path) and not args.force and checksum_does_match(output_path, checksums)):
+            if(exists(output_path) and not args.force and pa.checksum_does_match(output_path, checksums)):
                 logging.info(str(datetime.now()) + " SKIPPED: " + f)
                 skip_cnt += 1
                 continue

--- a/tests/test_subscriber_extracting_checksums.py
+++ b/tests/test_subscriber_extracting_checksums.py
@@ -1,5 +1,5 @@
-from subscriber.podaac_data_subscriber import extract_checksums
 import json
+from subscriber.podaac_access import extract_checksums
 
 minimal_granule_search_results = """{
   "hits": 13,

--- a/tests/test_subscriber_matching_checksums.py
+++ b/tests/test_subscriber_matching_checksums.py
@@ -1,4 +1,4 @@
-from subscriber.podaac_data_subscriber import checksum_does_match
+from subscriber.podaac_access import checksum_does_match
 
 def test_checksum_does_match__positive_match_md5(tmpdir):
   output_path = str(tmpdir) + '/tmp.nc'


### PR DESCRIPTION
Addresses Issue #17 - adding to what was done in [PR 63](https://github.com/podaac/data-subscriber/pull/63)

Changes:
- The downloader will skip downloading a file if the file already exists (and its checksum matches with CMR). 
- Also adds the --force/-f flag to force the downloader download files - even when they already exist.
- Added documentation to the Downloader.md file, and changed the documentation for this feature in the Subscriber.md file. (The new description makes more sense to me, but let me know any suggestions you might have on this).

