### PR TITLE
Added note about User Installs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ usage: PO.DAAC bulk-data downloader [-h] -c COLLECTION -d OUTPUTDIRECTORY [--cyc
 ...
 ```
 
+**Note:** If after installation, the `podaac-data-subscriber` or `podaac-data-downloader` commands are not available, you may need to add the script location to the PATH. This could be due to a *User Install* of the python package, which is common on shared systems where python packages are installed for the user (not the system). See [Installing to the User Site](https://packaging.python.org/en/latest/tutorials/installing-packages/#installing-to-the-user-site) and [User Installs](https://pip.pypa.io/en/latest/user_guide/#user-installs) for more information on finding the location of installed scripts and adding them to the PATH.
+
 ## Step 1:  Get Earthdata Login     
 This step is needed only if you dont have an Earthdata login already.
 https://urs.earthdata.nasa.gov/


### PR DESCRIPTION
Addresses #77.

Just adds a note in the installation section of the README that covers the situation where the podaac-data-subscriber and
podaac-data-downloader scripts are not available after install (due to not being on the PATH).

Suggestions very welcome if more info should be added or it could be worded more clearly.