### PR TITLE
Fixed bug introduced in issues/36 where valid bboxes were raising an exception

### DIFF
--- a/subscriber/podaac_access.py
+++ b/subscriber/podaac_access.py
@@ -188,10 +188,7 @@ def validate(args):
             raise ValueError(
                 "Error parsing '--bounds': " + args.bbox + ". Format is W Longitude,S Latitude,E Longitude,N Latitude without spaces ")  # noqa E501
 
-        if num_bounds[0] > num_bounds[2]:
-            raise ValueError('Error parsing "--bounds": W Longitude must be <= E Longitude')
-
-        if num_bounds[1] > num_bounds[2]:
+        if num_bounds[1] > num_bounds[3]:
             raise ValueError('Error parsing "--bounds": S Latitude must be <= N Latitude')
 
 

--- a/tests/test_subscriber.py
+++ b/tests/test_subscriber.py
@@ -164,6 +164,17 @@ def test_validate():
     with pytest.raises(ValueError):
         a = validate(["-c", "viirs", "-d", "/data", "-b=-180,-90,180", "-m", "100"])
 
+    # bbox crossing the IDL should not raise exception
+    validate(["-c", "viirs", "-d", "/data", "-dy", "-e", ".nc", "-m", "60", "-b=120,-60,-120,60"])
+    # valid bbox values should not raise exception
+    validate(["-c", "viirs", "-d", "/data", "-dy", "-e", ".nc", "-m", "60", "-b=-180,-60,-120,60"])
+    validate(["-c", "viirs", "-d", "/data", "-dy", "-e", ".nc", "-m", "60", "-b=-170,-20,-30,20"])
+
+    # bbox with invalid latitude values should raise an exception
+    with pytest.raises(ValueError):
+        validate(["-c", "viirs", "-d", "/data", "-b=-180,90,180,-90", "-m", "100"])
+
+
     # #don't work
     # with pytest.raises(SystemExit):
     #     a = validate([])


### PR DESCRIPTION
UAT for 1.15.0 found a bug where valid bboxes were raising an exception. There were two main issues:

1. A check was added to ensure W <= E. This is not necessary, as that constraint would not hold if querying across the IDL. 
  - Removed this validation step altogether
2. There was a bug when checking if S <= N. The code was actually checking if S <= E, which is incorrect.
  - Fixed this bug

Did not update changelog, as this bug was introduced in #142 which has not yet been officially released. 

Fixes #148 