### PR TITLE
Fix failing unit test to correct value returned by CMR

### DIFF
--- a/tests/test_subscriber.py
+++ b/tests/test_subscriber.py
@@ -85,8 +85,8 @@ def test_search_after():
         'bounding_box': "-180,-90,180,90",
     }
     results = pa.get_search_results(params, True)
-    assert results['hits'] == 3751
-    assert len(results['items']) == 3751
+    assert results['hits'] == 3762
+    assert len(results['items']) == 3762
 
 def test_update_format_change(cleanup_update_test):
     print("Running Test")


### PR DESCRIPTION
Updated failing test. 

```
>       assert results['hits'] == 3751
E       assert 3762 == 3751

tests\test_subscriber.py:88: AssertionError
=========================== short test summary info ===========================
FAILED tests/test_subscriber.py::test_search_after - assert [37](https://github.com/podaac/data-subscriber/actions/runs/7745910236/job/21122928083?pr=154#step:7:38)62 == 3751
================ 1 failed, 19 passed, 12 deselected in 13.95s =================
Error: Process completed with exit code 1.
```

The CMR query being executed by this test is now returning 3762 hits, not 3751. 