### PR TITLE
Added automatic creation of .netrc if none exists to address issue #93

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
+### Fixed
 ### Added
 - Added error messages to inform user if .harmony file is formatted incorrectly or missing a key
+- Added error message if .netrc file is not found and prompt for Earthdata login credentials to create a .netrc in the user's home directory
+### Changed
 
 ## [1.15.2]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - Added error messages to inform user if .harmony file is formatted incorrectly or missing a key
 - Added error message if .netrc file is not found and prompt for Earthdata login credentials to create a .netrc in the user's home directory
+- Added note about how to change permission of .netrc file for mac and linux
 ### Changed
 
 ## [1.15.2]

--- a/README.md
+++ b/README.md
@@ -91,7 +91,9 @@ machine urs.earthdata.nasa.gov
     password podaacIsAwesome
 ```
 
-**If the script cannot find the netrc file, you will be prompted to enter the username and password and the script wont be able to generate the CMR token**
+**If the script cannot find the netrc file, you will be prompted to enter the username and password to create one automatically. Without a netrc file the script won't be able to generate the CMR token**
+
+**If using MacOS or Linux you will need to change the permissions of the netrc file by running chmod og-rw .netrc**
 
 
 ## Advanced Usage

--- a/subscriber/podaac_access.py
+++ b/subscriber/podaac_access.py
@@ -26,6 +26,7 @@ import requests
 import tenacity
 from datetime import datetime
 import getpass
+import platform
 
 __version__ = "1.15.2"
 extensions = ["\\.nc", "\\.h5", "\\.zip", "\\.tar.gz", "\\.tiff"]
@@ -86,9 +87,11 @@ def create_netrc_file(response):
         
         with open(file_path, "w") as file:
             file.write(netrc_content)
-        
-        # change .netrc permissions
-        subprocess.run(["chmod", "og-rw", file_path])
+
+        # running this on windows will cause the program to crash and is not necessary
+        if platform.system() != 'Windows':
+            # change .netrc permissions
+            subprocess.run(["chmod", "og-rw", file_path])
 
     if response.lower() == 'n':
         logging.info('Go to https://urs.earthdata.nasa.gov/users/new to create an Earthdata login')


### PR DESCRIPTION
If no .netrc file is detected the program will ask if the user has an Earthdata login. If not it will give them the link to create one. If so It will prompt for credentials and automatically create a .netrc file in the home directory.

I changed the readme to say that if not .netrc file exists then one will be automatically created if the user has Earthdata login credentials. 

I also added a note in the readme that the permissions for the .netrc file should be changed for mac and linux users to address issue #152