### PR TITLE
Added automatic creation of .netrc if none exists to address issue #93 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
+### Fixed
 ### Added
 - Added error messages to inform user if .harmony file is formatted incorrectly or missing a key
+- Added error message if .netrc file is not found and prompt for Earthdata login credentials to create a .netrc in the user's home directory
+### Changed
 
 ## [1.15.2]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - Added error messages to inform user if .harmony file is formatted incorrectly or missing a key
 - Added error message if .netrc file is not found and prompt for Earthdata login credentials to create a .netrc in the user's home directory
+- Added note about how to change permission of .netrc file for mac and linux
 ### Changed
 
 ## [1.15.2]

--- a/README.md
+++ b/README.md
@@ -91,7 +91,9 @@ machine urs.earthdata.nasa.gov
     password podaacIsAwesome
 ```
 
-**If the script cannot find the netrc file, you will be prompted to enter the username and password and the script wont be able to generate the CMR token**
+**If the script cannot find the netrc file, you will be prompted to enter the username and password to create one automatically. Without a netrc file the script won't be able to generate the CMR token**
+
+**If using MacOS or Linux you will need to change the permissions of the netrc file by running chmod og-rw .netrc**
 
 
 ## Advanced Usage

--- a/subscriber/podaac_access.py
+++ b/subscriber/podaac_access.py
@@ -26,6 +26,7 @@ import requests
 import tenacity
 from datetime import datetime
 import getpass
+import platform
 
 __version__ = "1.15.2"
 extensions = ["\\.nc", "\\.h5", "\\.zip", "\\.tar.gz", "\\.tiff"]
@@ -86,9 +87,11 @@ def create_netrc_file(response):
         
         with open(file_path, "w") as file:
             file.write(netrc_content)
-        
-        # change .netrc permissions
-        subprocess.run(["chmod", "og-rw", file_path])
+
+        # running this on windows will cause the program to crash and is not necessary
+        if platform.system() != 'Windows':
+            # change .netrc permissions
+            subprocess.run(["chmod", "og-rw", file_path])
 
     if response.lower() == 'n':
         logging.info('Go to https://urs.earthdata.nasa.gov/users/new to create an Earthdata login')

--- a/subscriber/podaac_access.py
+++ b/subscriber/podaac_access.py
@@ -25,8 +25,6 @@ from packaging import version
 import requests
 import tenacity
 from datetime import datetime
-import getpass
-import platform
 
 __version__ = "1.15.2"
 extensions = ["\\.nc", "\\.h5", "\\.zip", "\\.tar.gz", "\\.tiff"]
@@ -65,38 +63,6 @@ IPAddr = "127.0.0.1"  # socket.gethostbyname(hostname)
 # You can log in manually by executing the cell below when running in the
 # notebook client in your browser.*
 
-
-def create_netrc_file(response):
-    """
-    Ask the user if they have created an Earthdata login
-    if so:
-    Prompt the user for their username and password
-    Use the credentials to create a .netrc file in the users home directory
-    if not:
-    Prompt the user to create an Earthdata login at the appropriate url
-    """
-    if response.lower() == 'y':
-        login = input('Enter your Earthdata username: ')
-        password = getpass.getpass('Enter your Earthdata password: ')
-        netrc_content = f"machine urs.earthdata.nasa.gov\n" \
-                        f"    login {login}\n" \
-                        f"    password {password}\n"
-        
-        home_dir = os.path.expanduser("~")
-        file_path = os.path.join(home_dir, ".netrc")
-        
-        with open(file_path, "w") as file:
-            file.write(netrc_content)
-
-        # running this on windows will cause the program to crash and is not necessary
-        if platform.system() != 'Windows':
-            # change .netrc permissions
-            subprocess.run(["chmod", "og-rw", file_path])
-
-    if response.lower() == 'n':
-        logging.info('Go to https://urs.earthdata.nasa.gov/users/new to create an Earthdata login')
-        exit()
-
 def setup_earthdata_login_auth(endpoint):
     """
     Set up the request library so that it authenticates against the given
@@ -109,15 +75,11 @@ def setup_earthdata_login_auth(endpoint):
     """
     try:
         username, _, password = netrc.netrc().authenticators(endpoint)
-    # FileNotFound = There's no .netrc file
-    except FileNotFoundError:
-        logging.warning("No .netrc file can be found. One will be attempted to be created.")
-        create_netrc_file(input('Do you have an Earthdata login? (y/n): '))
-        username, _, password = netrc.netrc().authenticators(endpoint)
-    # TypeError = The endpoint isn't in the netrc file,
-    #  causing the below to try unpacking None
-    except TypeError:
-        logging.warning("The endpoint isn't in the netrc file or is incorrect")
+    except (FileNotFoundError, TypeError):
+        # FileNotFound = There's no .netrc file
+        # TypeError = The endpoint isn't in the netrc file,
+        #  causing the above to try unpacking None
+        logging.warning("There's no .netrc file or the The endpoint isn't in the netrc file")
 
 
     manager = request.HTTPPasswordMgrWithDefaultRealm()

--- a/subscriber/podaac_data_downloader.py
+++ b/subscriber/podaac_data_downloader.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta
 from os import makedirs
 from os.path import isdir, basename, join, exists
 from urllib.error import HTTPError
+import getpass
 
 from subscriber import podaac_access as pa
 from subscriber import subsetting
@@ -120,6 +121,35 @@ def create_parser():
 
     return parser
 
+def netrc_file_exists():
+    # get the path for .netrc file
+    home_dir = os.path.expanduser("~")
+    netrc_path = os.path.join(home_dir, ".netrc")
+
+    return os.path.isfile(netrc_path)
+
+def create_netrc_file():
+    """
+    Prompt the user for their username and password
+    Use the credentials to create a .netrc file in the users home directory
+    """
+    login = input('Enter your Earthdata username: ')
+    password = getpass.getpass('Enter your Earthdata password: ')
+    netrc_content = f"machine urs.earthdata.nasa.gov\n" \
+                    f"    login {login}\n" \
+                    f"    password {password}\n"
+
+    # get the path for .netrc file
+    home_dir = os.path.expanduser("~")
+    netrc_path = os.path.join(home_dir, ".netrc")
+
+    # os.open netrc permissions
+    netrc_permissions = 0o600
+
+    # Create and open the .netrc file with the correct permissions
+    fd = os.open(netrc_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, netrc_permissions)
+    with os.fdopen(fd, 'w') as file:
+        file.write(netrc_content)
 
 def run(args=None):
     if args is None:
@@ -137,6 +167,13 @@ def run(args=None):
     except ValueError as v:
         logging.error(str(v))
         exit(1)
+
+    if not netrc_file_exists():
+        if input('Do you have an Earthdata login? (y/n): ').lower() == 'y':
+            create_netrc_file()
+        else:
+            logging.info('Go to https://urs.earthdata.nasa.gov/users/new to create an Earthdata login')
+            exit()
 
     pa.setup_earthdata_login_auth(edl)
     token = pa.get_token(token_url)

--- a/subscriber/podaac_data_subscriber.py
+++ b/subscriber/podaac_data_subscriber.py
@@ -20,6 +20,7 @@ from datetime import datetime, timedelta
 from os import makedirs
 from os.path import isdir, basename, join, isfile, exists
 from urllib.error import HTTPError
+import getpass
 
 from subscriber import podaac_access as pa
 from subscriber import subsetting


### PR DESCRIPTION
If no .netrc file is detected the program will ask if the user has an Earthdata login. If not it will give them the link to create one. If so It will prompt for credentials and automatically create a .netrc file in the home directory.

I changed the readme to say that if not .netrc file exists then one will be automatically created if the user has Earthdata login credentials.

I also added a note in the readme that the permissions for the .netrc file should be changed for mac and linux users to address issue #152