### PR TITLE
[Feature/PDOAAC-6302] (issue/137) add in small notificaiton on using `-gr` flag

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       max-parallel: 2
       matrix:
-        python-version: [ "3.7", "3.8", "3.9", "3.10" ]
+        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
         poetry-version: [ "1.5.1" ]
         os: [ ubuntu-22.04, macos-latest, windows-latest ]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       max-parallel: 2
       matrix:
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.8", "3.9", "3.10", "3.11" ]
         poetry-version: [ "1.5.1" ]
         os: [ ubuntu-22.04, macos-latest, windows-latest ]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -62,7 +62,7 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        python-version: [ "3.7", "3.8", "3.9", "3.10" ]
+        python-version: [ "3.8", "3.9", "3.10", "3.11" ]
         poetry-version: [ "1.5.1" ]
         os: [ ubuntu-22.04, macos-latest, windows-latest ]
     runs-on: ${{ matrix.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added error messages to inform user if .harmony file is formatted incorrectly or missing a key
 - **PODAAC-6302 (issues/137)**
   - Added small notification when `-gr` is being used but 0 granules are returned
-- Added python versions 3.11 and 3.12 to supported builds
+- Added python versions 3.11 to supported builds
 ### Fixed
 - **PODAAC-6303 (issues/167)**
   - Fixed issue where -gr and -sd/-ed (temporal) cannot be used together as a query

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added error messages to inform user if .harmony file is formatted incorrectly or missing a key
 - **PODAAC-6302 (issues/137)**
   - Added small notification when `-gr` is being used but 0 granules are returned
+- Added python versions 3.11 and 3.12 to supported builds
 ### Fixed
 - **PODAAC-6303 (issues/167)**
   - Fixed issue where -gr and -sd/-ed (temporal) cannot be used together as a query
+### Removed
+- Removed python 3.7 from supported builds
 
 
 ## [1.15.2]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 ### Added
 - Added error messages to inform user if .harmony file is formatted incorrectly or missing a key
+- **PODAAC-6302 (issues/137)**
+  - Added small notification when `-gr` is being used but 0 granules are returned
 
 ## [1.15.2]
 ### Fixed

--- a/subscriber/podaac_data_downloader.py
+++ b/subscriber/podaac_data_downloader.py
@@ -280,8 +280,12 @@ def cmr_downloader(args, token, data_path):
     if args.verbose:
         logging.info(str(results['hits']) + " granules found for " + short_name)  # noqa E501
 
-    if granule is not None and results['hits'] == 0:
-        logging.info("** 0 granules found with -gr (granuleUR) flag; tried using wildcards (*/%)? **")
+    if granule is not None and results.get('hits', 0) == 0:
+        logging.info("** 0 granules found with -gr (granuleUR) flag.            **")
+        logging.info("** If you expected granules to be found and downloaded,   **")
+        logging.info("** please try using wildcards (*/%) in the -gr parameter. **")
+        logging.info("**    -gr=\"*data*\" for multiple characters            **")
+        logging.info("**    -gr=\"_A%T_\" for a single character              **")
 
     if any([args.dy, args.dydoy, args.dymd]):
         file_start_times = pa.parse_start_times(results)

--- a/subscriber/podaac_data_downloader.py
+++ b/subscriber/podaac_data_downloader.py
@@ -280,6 +280,9 @@ def cmr_downloader(args, token, data_path):
     if args.verbose:
         logging.info(str(results['hits']) + " granules found for " + short_name)  # noqa E501
 
+    if granule is not None and results['hits'] == 0:
+        logging.info("** 0 granules found with -gr (granuleUR) flag; tried using wildcards (*/%)? **")
+
     if any([args.dy, args.dydoy, args.dymd]):
         file_start_times = pa.parse_start_times(results)
     elif args.cycle:
@@ -315,9 +318,6 @@ def cmr_downloader(args, token, data_path):
     # Make this a non-verbose message
     # if args.verbose:
     logging.info("Found " + str(len(downloads)) + " total files to download")
-
-    if granule is not None and len(downloads) == 0:
-        logging.info("** 0 granules found with -gr (granuleUR) flag; tried using wildcards (*/%)? **")
 
     if download_limit:
         logging.info("Limiting downloads to " + str(args.limit) + " total files")

--- a/subscriber/podaac_data_downloader.py
+++ b/subscriber/podaac_data_downloader.py
@@ -315,6 +315,10 @@ def cmr_downloader(args, token, data_path):
     # Make this a non-verbose message
     # if args.verbose:
     logging.info("Found " + str(len(downloads)) + " total files to download")
+
+    if granule is not None and len(downloads) == 0:
+        logging.info("** 0 granules found with -gr (granuleUR) flag; tried using wildcards (*/%)? **")
+
     if download_limit:
         logging.info("Limiting downloads to " + str(args.limit) + " total files")
 

--- a/subscriber/podaac_data_downloader.py
+++ b/subscriber/podaac_data_downloader.py
@@ -318,7 +318,6 @@ def cmr_downloader(args, token, data_path):
     # Make this a non-verbose message
     # if args.verbose:
     logging.info("Found " + str(len(downloads)) + " total files to download")
-
     if download_limit:
         logging.info("Limiting downloads to " + str(args.limit) + " total files")
 

--- a/subscriber/podaac_data_downloader.py
+++ b/subscriber/podaac_data_downloader.py
@@ -284,8 +284,8 @@ def cmr_downloader(args, token, data_path):
         logging.info("** 0 granules found with -gr (granuleUR) flag.            **")
         logging.info("** If you expected granules to be found and downloaded,   **")
         logging.info("** please try using wildcards (*/%) in the -gr parameter. **")
-        logging.info("**    -gr=\"*data*\" for multiple characters              **")
-        logging.info("**    -gr=\"_A%T_\" for a single character                **")
+        logging.info("**    -gr=\"*data*\" for multiple characters                **")
+        logging.info("**    -gr=\"_A%T_\" for a single character                  **")
 
     if any([args.dy, args.dydoy, args.dymd]):
         file_start_times = pa.parse_start_times(results)

--- a/subscriber/podaac_data_downloader.py
+++ b/subscriber/podaac_data_downloader.py
@@ -284,8 +284,8 @@ def cmr_downloader(args, token, data_path):
         logging.info("** 0 granules found with -gr (granuleUR) flag.            **")
         logging.info("** If you expected granules to be found and downloaded,   **")
         logging.info("** please try using wildcards (*/%) in the -gr parameter. **")
-        logging.info("**    -gr=\"*data*\" for multiple characters            **")
-        logging.info("**    -gr=\"_A%T_\" for a single character              **")
+        logging.info("**    -gr=\"*data*\" for multiple characters              **")
+        logging.info("**    -gr=\"_A%T_\" for a single character                **")
 
     if any([args.dy, args.dydoy, args.dymd]):
         file_start_times = pa.parse_start_times(results)


### PR DESCRIPTION
Throwing in a small notification when -gr flag is used and no results have returned
looks like follows
```
> podaac-data-downloader -c OSCAR_L4_OC_third-deg -d . -gr="oscar_vel11181.nc.gz" -e nc.gz
[2025-03-06 10:38:36,069] {podaac_data_downloader.py:284} INFO - ** 0 granules found with -gr (granuleUR) flag.            **
[2025-03-06 10:38:36,070] {podaac_data_downloader.py:285} INFO - ** If you expected granules to be found and downloaded,   **
[2025-03-06 10:38:36,070] {podaac_data_downloader.py:286} INFO - ** please try using wildcards (*/%) in the -gr parameter. **
[2025-03-06 10:38:36,070] {podaac_data_downloader.py:287} INFO - **    -gr="*data*" for multiple characters                **
[2025-03-06 10:38:36,070] {podaac_data_downloader.py:288} INFO - **    -gr="_A%T_" for a single character                  **
[2025-03-06 10:38:36,070] {podaac_data_downloader.py:324} INFO - Found 0 total files to download
[2025-03-06 10:38:36,070] {podaac_data_downloader.py:376} INFO - Downloaded Files: 0
[2025-03-06 10:38:36,070] {podaac_data_downloader.py:377} INFO - Failed Files:     0
[2025-03-06 10:38:36,070] {podaac_data_downloader.py:378} INFO - Skipped Files:    0
[2025-03-06 10:38:36,070] {podaac_data_downloader.py:177} INFO - Success Count: 0
[2025-03-06 10:38:36,071] {podaac_data_downloader.py:186} INFO - END
```