### PR TITLE
[Feature/podaac-6305] Fix issue with collections without perfect matching file names with granule ur's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - **PODAAC-6303 (issues/167)**
   - Fixed issue where -gr and -sd/-ed (temporal) cannot be used together as a query
+- **PODAAC-6305 (issues/160)**
+  - Fixed issue when -gr and cycle are used together, and when sometimes the granule name is a subset of what's found in CMR (`SWOT_GPR_2PfP474_001_20230328_220206_20230328_225311` in `SWOT_GPR_2PfP474_002_20230328_225311_20230328_234417_swot`)
 
 ## [1.15.2]
 ### Fixed

--- a/subscriber/podaac_access.py
+++ b/subscriber/podaac_access.py
@@ -293,7 +293,7 @@ def prepare_time_output(times, prefix, file, args, ts_shift):
 
 
 def prepare_cycles_output(data_cycles, prefix, file):
-    """"
+    """
     Create output directory using OUTPUT_DIR/CYCLE_NUMBER
     .update stored in OUTPUT_DIR/
 
@@ -301,7 +301,7 @@ def prepare_cycles_output(data_cycles, prefix, file):
     ----------
     data_cycles : list
         list of tuples consisting of granule names and cycle numbers
-        prefix : string
+    prefix : string
         prefix for output path, either custom output -d or short name
     file : string
         granule file name
@@ -311,8 +311,12 @@ def prepare_cycles_output(data_cycles, prefix, file):
     write_path : string
         string path to where granules will be written
     """
+    '''
+    for each 'data_cycles', build a list that contains the substring 'file' in the granule column, 
+    and get the first tuple
+    '''
     cycle_match = [
-        cycle for cycle in data_cycles if cycle[0] == splitext(basename(file))[0]
+        cycle for cycle in data_cycles if splitext(basename(file))[0] in cycle[0]
     ][0]
     cycle_dir = "c" + cycle_match[1].zfill(4)
     check_dir(join(prefix, cycle_dir))

--- a/tests/test_downloader_regression.py
+++ b/tests/test_downloader_regression.py
@@ -123,4 +123,3 @@ def test_downloader_temporal_and_granule_together():
     assert len([name for name in os.listdir('./TMP') if
                 os.path.isfile('./TMP/' + name) and "citation.txt" not in name]) == 2
     shutil.rmtree('./TMP')
-    assert True


### PR DESCRIPTION
Fixes https://github.com/podaac/data-subscriber/issues/160
by adjusting the search for "file being a subset of the granule ur, return the cycle"

This fix works for both the subscriber and downloader