### PR TITLE
Validate that start date precedes end date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
+## [Unreleased]
+### Fixed
+- Raise a clear error when --start-date is later than --end-date instead of an opaque HTTP 400 from CMR [145](https://github.com/podaac/data-subscriber/issues/145)
+
 ## [1.15.2]
 ### Fixed
 - Fixed bug where --subset in combination with the subscriber caused errors

--- a/subscriber/podaac_access.py
+++ b/subscriber/podaac_access.py
@@ -211,7 +211,7 @@ def validate(args):
 
     if start is not None and end is not None and start > end:
         raise ValueError(
-            "Start date and end date are out of order. End date needs to be a later time than start date.")  # noqa E501
+            "--end-date must be greater than or equal to --start-date.")
 
     if 'minutes' in args:
         if args.minutes:

--- a/subscriber/podaac_access.py
+++ b/subscriber/podaac_access.py
@@ -192,19 +192,26 @@ def validate(args):
             raise ValueError('Error parsing "--bounds": S Latitude must be <= N Latitude')
 
 
+    start = None
+    end = None
+
     if args.startDate:
         try:
-            datetime.strptime(args.startDate, '%Y-%m-%dT%H:%M:%SZ')
+            start = datetime.strptime(args.startDate, '%Y-%m-%dT%H:%M:%SZ')
         except ValueError:
             raise ValueError(
                 "Error parsing '--start-date' date: " + args.startDate + ". Format must be like 2021-01-14T00:00:00Z")  # noqa E501
 
     if args.endDate:
         try:
-            datetime.strptime(args.endDate, '%Y-%m-%dT%H:%M:%SZ')
+            end = datetime.strptime(args.endDate, '%Y-%m-%dT%H:%M:%SZ')
         except ValueError:
             raise ValueError(
                 "Error parsing '--end-date' date: " + args.endDate + ". Format must be like 2021-01-14T00:00:00Z")  # noqa E501
+
+    if start is not None and end is not None and start > end:
+        raise ValueError(
+            "Start date and end date are out of order. End date needs to be a later time than start date.")  # noqa E501
 
     if 'minutes' in args:
         if args.minutes:

--- a/tests/test_subscriber.py
+++ b/tests/test_subscriber.py
@@ -146,6 +146,13 @@ def test_validate():
     assert a.endDate == '2021-01-01T00:00:00Z'
     assert a.provider == "POCLOUD"
 
+    # start date equal to end date is allowed
+    validate(["-c", "dataset", "-d", "/data", "-sd", "2021-01-01T00:00:00Z", "-ed", "2021-01-01T00:00:00Z"])
+
+    # start date after end date should raise a clear error
+    with pytest.raises(ValueError):
+        validate(["-c", "dataset", "-d", "/data", "-sd", "2021-01-01T00:00:00Z", "-ed", "2020-01-01T00:00:00Z"])
+
     a = validate(["-c", "dataset", "-d", "/data", "-p", "ANEWCLOUD"])
     assert a.provider == 'ANEWCLOUD'
 


### PR DESCRIPTION
Right now the start and end dates aren't checked against each other, so if you pass a start date that's later than the end date the bad range just gets sent to CMR and all you see is an HTTP 400, which is pretty confusing. This adds an order check so you get a clear message instead, using the wording suggested in #145. Equal start and end dates are still allowed.

I added a couple of assertions to test_validate covering both the out-of-order case and the equal-dates case. Thanks for taking a look.